### PR TITLE
ジャンル新規作成の非同期通信化

### DIFF
--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -7,10 +7,15 @@ class Admin::GenresController < ApplicationController
   def create
     @genre = Genre.new(genre_params)
     if @genre.save
-      redirect_to admin_genres_path
+      @genres = Genre.all
+      respond_to do |format|
+        format.js
+      end
     else
       @genres = Genre.all
-      render :index
+      respond_to do |format|
+        format.js { render :create_error }
+      end
     end
   end
 

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -2,5 +2,5 @@ class Genre < ApplicationRecord
 
   has_many :items, dependent: :destroy
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: { case_sensitive: false, message: "はすでに存在しています" }
 end

--- a/app/views/admin/genres/_form.html.erb
+++ b/app/views/admin/genres/_form.html.erb
@@ -1,9 +1,9 @@
 <div class="row">
-  <%= form_with url:admin_genres_path, model: genre do |f| %>
+  <%= form_with url:admin_genres_path, model: genre, local: false do |f| %>
     <table>
       <tr>
         <td><%= f.label :name, "ジャンル名" %></td>
-        <td><%= f.text_field :name, placeholder: "ジャンル名" %></td>
+        <td><%= f.text_field :name, placeholder: "ジャンル名", id:"text_field" %></td>
         <td><%= f.submit '新規登録', class:'btn btn-success' %></td>
       </tr>
     </table>

--- a/app/views/admin/genres/create.js.erb
+++ b/app/views/admin/genres/create.js.erb
@@ -1,0 +1,3 @@
+$("#error-messages").html("");
+$("#genre_index").html(" <%= j(render 'admin/genres/index', genres:@genres) %> ");
+$("#text_field").val("");

--- a/app/views/admin/genres/create_error.js.erb
+++ b/app/views/admin/genres/create_error.js.erb
@@ -1,0 +1,1 @@
+$("#error-messages").html("<%= j(render 'layouts/errors', obj: @genre) %>");

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -4,10 +4,12 @@
     <h4>ジャンル一覧・追加</h4>
   </div>
 
-  <%= render 'layouts/errors', obj:@genre %>
+  <div id="error-messages"></div>>
 
   <%= render 'form', genre:@genre %>
 
-  <%= render 'index', genres:@genres %>
+  <div id="genre_index">
+    <%= render 'index', genres:@genres %>
+  </div>
 
 </div>


### PR DESCRIPTION
ジャンル新規作成を非同期通信化しました。
ジャンル新規作成の際、すでに存在するジャンル名は作成できないようにしました。